### PR TITLE
Update to new page name

### DIFF
--- a/redirect-patroller.js
+++ b/redirect-patroller.js
@@ -111,7 +111,7 @@ async function getPatrollableUsers( bot ) {
 	const result = await bot.request( {
 		action: 'query',
 		prop: 'revisions',
-		titles: 'Wikipedia:New pages patrol/Redirect whitelist',
+		titles: 'Wikipedia:New pages patrol/Redirect allowlist',
 		rvslots: '*',
 		rvprop: 'content'
 	} );


### PR DESCRIPTION
"New pages patrol/Redirect whitelist" to "New pages patrol/Redirect allowlist". Should be merged if https://en.wikipedia.org/wiki/Wikipedia_talk:New_pages_patrol/Redirect_whitelist#Requested_move_31_March_2022 is closed.